### PR TITLE
fix: download results from us-2-west bucket

### DIFF
--- a/rest/buckets/results_bucket.py
+++ b/rest/buckets/results_bucket.py
@@ -1,4 +1,5 @@
 import boto3
+from botocore.client import Config
 
 
 class ResultsBucket:
@@ -10,6 +11,7 @@ class ResultsBucket:
             endpoint_url=endpoint_url,
             aws_access_key_id=access_key_id,
             aws_secret_access_key=secret_access_key,
+            config=Config(signature_version="s3v4"),
         )
 
     def put_file_to_bucket(self, content_as_string, prefix=None, file_name="file"):


### PR DESCRIPTION
closes #78 

The cause of the issue is that we use `rasterio` to download tiff files from the S3 bucket, with a pre-signed url. The pre-signed url differed between `us-west-2` and `eu-central-1`, where `us-west-2` url was using signature version 2 which resulted an a 403 error when `raterio.gdal` was trying to fetch the image.